### PR TITLE
ci: add org-level Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Copilot Code Review Instructions
+
+## Do NOT Report
+
+Issues that static analysis tools catch. Linters, formatters, type checkers,
+and other automated tools already run in CI. Copilot should not duplicate
+their work. Examples:
+
+- Linting violations (ESLint, Ruff, actionlint, shellcheck, etc.)
+- Formatting issues (Prettier, Black, gofmt, etc.)
+- Type errors (TypeScript, mypy, etc.)
+- Security scanner findings (zizmor, Trivy, gitleaks, etc.)
+
+If a tool in CI would flag it, do not comment on it.
+
+## Review Focus
+
+- Bugs and logic errors
+- Security vulnerabilities not caught by automated scanners
+- Breaking changes not mentioned in the PR description
+- Missing error handling in new code paths
+- Missing tests for new functionality
+- Architecture and design concerns
+
+## Guidelines
+
+- Only comment when you have high confidence an issue exists
+- Be concise: one sentence per comment when possible
+- Provide actionable suggestions, not vague observations

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,16 +2,16 @@
 
 ## Do NOT Report
 
-Issues that static analysis tools catch. Linters, formatters, type checkers,
-and other automated tools already run in CI. Copilot should not duplicate
-their work. Examples:
+- Code formatting (indentation, whitespace, line length, trailing commas)
+- Import ordering or grouping
+- Missing or extra semicolons
+- Unused variables or unused imports
+- Type annotation issues or missing type hints
+- Shell script quoting or syntax that shellcheck would flag
+- YAML/JSON syntax issues
+- Known security patterns that scanners detect (hardcoded secrets, CVEs in dependencies)
 
-- Linting violations (ESLint, Ruff, actionlint, shellcheck, etc.)
-- Formatting issues (Prettier, Black, gofmt, etc.)
-- Type errors (TypeScript, mypy, etc.)
-- Security scanner findings (zizmor, Trivy, gitleaks, etc.)
-
-If a tool in CI would flag it, do not comment on it.
+These are handled by automated tools. Focus on what requires human judgment.
 
 ## Review Focus
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,14 +13,19 @@
 
 These are handled by automated tools. Focus on what requires human judgment.
 
+## Scope
+
+Only review **changed lines** in the PR diff. Do not comment on existing
+code that was not modified in this PR. Pre-existing issues are out of scope.
+
 ## Review Focus
 
-- Bugs and logic errors
+- Bugs and logic errors in changed code
 - Security vulnerabilities not caught by automated scanners
 - Breaking changes not mentioned in the PR description
 - Missing error handling in new code paths
 - Missing tests for new functionality
-- Architecture and design concerns
+- Architecture and design concerns in the changes
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` with org-wide review rules
- Tell Copilot to skip issues that static analysis tools already catch in CI
- Focus review on bugs, security, breaking changes, architecture

## Key Principle
> Copilot should complement static analysis, not duplicate it. Anything a linter, formatter, or type checker can find should be excluded.

## Test plan
- [ ] Verify Copilot reads instructions on next PR review
- [ ] Confirm linter-type findings are no longer reported

Closes #6